### PR TITLE
Add VPC connector variable and mark config as sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ parameters in when using as a module:
   - `function_timeout` (number, optional): a timeout for the Cloud Function (defaults to `240` seconds)
   - `retry_minimum_backoff` (string, optional): minimum backoff time for exponential backoff retries in Cloud Run. Defaults to 10s.
   - `retry_maximum_backoff` (string, optional): maximum backoff time for exponential backoff retries in Cloud Run. Defaults to 600s.
+  - `vpc_connector` (string, optional): ID of the serverless VPC Connector for the Cloud Function
   - `cloud_run` (boolean, optional): deploy via Cloud Run instead of Cloud Function. Defaults to `false`. If set to `true`, also specify `cloud_run_container`.
   - `cloud_run_container` (string, optional): container image to deploy on Cloud Run. See previous parameter.
 

--- a/main.tf
+++ b/main.tf
@@ -231,6 +231,8 @@ resource "google_cloudfunctions_function" "function" {
   entry_point           = "process_pubsub"
   timeout               = var.function_timeout
 
+  vpc_connector = var.vpc_connector
+
   event_trigger {
     event_type = "google.pubsub.topic.publish"
     resource   = var.pubsub_topic

--- a/variables.tf
+++ b/variables.tf
@@ -114,7 +114,7 @@ variable "retry_maximum_backoff" {
 variable "vpc_connector" {
   type        = string
   description = "VPC connector ID for Cloud Function serverless access"
-  default     = ""
+  default     = null
 }
 
 variable "cloud_run" {

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,8 @@ variable "config" {
   type        = string
   description = "Configuration contents (either specify config_file or config)"
 
-  default = null
+  default   = null
+  sensitive = true
 }
 
 variable "service_account" {
@@ -108,6 +109,12 @@ variable "retry_maximum_backoff" {
   type        = string
   description = "Maximum retry backoff (value between 0-600 seconds, suffixed with s, default 600s, Cloud Run Only)"
   default     = "600s"
+}
+
+variable "vpc_connector" {
+  type        = string
+  description = "VPC connector ID for Cloud Function serverless access"
+  default     = ""
 }
 
 variable "cloud_run" {


### PR DESCRIPTION
Although the project's README file mentions the option to use a serverless VPC connector to access mail servers, this code was not implemented in the module. I added the option to provide the ID of a VPC connector which is passed on to the Cloud Function to enable this functionality. If a link is not provided, no connector is associated.

I also marked the `config` variable as sensitive, since it can contain credentials.