### PR TITLE
fix/disable-vertex-search

### DIFF
--- a/examples/gemini-pro-slack-bot/main.tf
+++ b/examples/gemini-pro-slack-bot/main.tf
@@ -72,6 +72,7 @@ module "function" {
     vertex_region = var.vertex_region
     vertex_model  = var.vertex_search.enabled == false ? var.vertex_model : var.vertex_model_multimodal
     api_enabled   = false
+    vertex_search_function = null
     }, var.vertex_search.enabled == true ? {
     api_enabled            = true
     vertex_search_function = module.api[""].run_service.url


### PR DESCRIPTION
## SUMMARY
this PR fixes a bug when apply terraform with vertex_serach disabled.

## PROBLEM
When run `terraform plan/apply` with the following vars to disable Vertex_search
```
vertex_search = {
  enabled      = false
  ...
}
```
an error is thrown

```

│ Error: Invalid function argument
│
│   on main.tf line 69, in module "function":
│   69:   config = templatefile("${path.module}/slack-bot.yaml", merge({
│   70:     slack_token   = var.slack_token
│   71:     slack_app_id  = var.slack_app_id
│   72:     vertex_region = var.vertex_region
│   73:     vertex_model  = var.vertex_search.enabled == false ? var.vertex_model : var.vertex_model_multimodal
│   74:     api_enabled   = false
│   75:     }, var.vertex_search.enabled == true ? {
│   76:     api_enabled            = true
│   77:     vertex_search_function = module.api[""].run_service.url
│   78:   } : {}))
│     ├────────────────
│     │ while calling templatefile(path, vars)
│     │ module.api is object with no attributes
│     │ var.slack_app_id is "AxxxU"
│     │ var.slack_token is "xxxxXy"
│     │ var.vertex_model is "gemini-1.5-pro-preview-0409"
│     │ var.vertex_model_multimodal is "gemini-1.5-pro-preview-0409"
│     │ var.vertex_region is "uxxxl1"
│     │ var.vertex_search.enabled is false
│
│ Invalid value for "vars" parameter: vars map does not contain key "vertex_search_function", referenced at ./slack-bot.yaml:138,19-41.
╵
```

the issue is shown in the last line 
```
vars map does not contain key "vertex_search_function", referenced at ./slack-bot.yaml:138,19-41.
```

## FIX
add a default vertex_search_function value in terraform main